### PR TITLE
Handle import of ethereum privkeys with 0x. Trust node by default 

### DIFF
--- a/cli/commands/keys/importprivate.go
+++ b/cli/commands/keys/importprivate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/mintkey"
+	"github.com/cybercongress/cyberd/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tendermint/btcd/btcec"
@@ -14,6 +15,8 @@ import (
 	"github.com/tendermint/tendermint/crypto/secp256k1"
 	"github.com/tendermint/tendermint/libs/cli"
 )
+
+const hashPrefix = "0x"
 
 func importPrivateKeyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -43,6 +46,10 @@ func importPrivateKeyCmd() *cobra.Command {
 				"Enter your private key (hex encoded):", bufStdin)
 			if err != nil {
 				return err
+			}
+
+			if util.HasPrefixIgnoreCase(privateKey, hashPrefix) {
+				privateKey = privateKey[len(hashPrefix):]
 			}
 
 			b, _ := hex.DecodeString(privateKey)

--- a/cli/main.go
+++ b/cli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	"github.com/cybercongress/cyberd/cli/commands/keys"
+	"github.com/spf13/viper"
 	"github.com/tendermint/go-amino"
 	"os"
 
@@ -66,6 +67,9 @@ func main() {
 		client.PostCommands(
 			cyberdcmd.LinkTxCmd(cdc),
 		)...)
+
+	// todo: hack till we don't handle with all merkle proofs
+	viper.SetDefault(client.FlagTrustNode, true)
 
 	executor := cli.PrepareMainCmd(cyberdcli, "CBD", os.ExpandEnv("$HOME/.cyberdcli"))
 	err := executor.Execute()

--- a/util/strings.go
+++ b/util/strings.go
@@ -1,0 +1,10 @@
+package util
+
+import "strings"
+
+func HasPrefixIgnoreCase(s, prefix string) bool {
+	lowerCaseS := strings.ToLower(s)
+	lowerCasePrefix := strings.ToLower(prefix)
+
+	return strings.HasPrefix(lowerCaseS, lowerCasePrefix)
+}


### PR DESCRIPTION
Handle import of ethereum privkeys with 0x. Trust node by default 
Closes #150 and #151 